### PR TITLE
android: add keylayout for combined joycons and drop procon support

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -14,9 +14,14 @@ LOCAL_SRC_FILES := \
 
 LOCAL_C_INCLUDES := $(LOCAL_PATH)/include
 
-LOCAL_SHARED_LIBRARIES := libevdev \
+LOCAL_SHARED_LIBRARIES := \
+    libevdev \
     libnl \
     liblog
+
+LOCAL_REQUIRED_MODULES := \
+    Vendor_057e_Product_2008.idc \
+    Vendor_057e_Product_2008.kl
 
 LOCAL_MODULE := joycond
 LOCAL_INIT_RC := android/joycond.rc
@@ -25,3 +30,21 @@ LOCAL_CPPFLAGS := -std=c++17 -Wno-error -fexceptions
 LOCAL_VENDOR_MODULE := true
 LOCAL_MODULE_OWNER := nintendo
 include $(BUILD_EXECUTABLE)
+
+include $(CLEAR_VARS)
+LOCAL_MODULE := Vendor_057e_Product_2008.kl
+LOCAL_SRC_FILES := android/Vendor_057e_Product_2008.kl
+LOCAL_MODULE_CLASS := ETC
+LOCAL_MODULE_PATH := $(TARGET_OUT_VENDOR)/usr/keylayout
+LOCAL_MODULE_TAGS := optional
+LOCAL_MODULE_OWNER := nintendo
+include $(BUILD_PREBUILT)
+
+include $(CLEAR_VARS)
+LOCAL_MODULE := Vendor_057e_Product_2008.idc
+LOCAL_SRC_FILES := android/Vendor_057e_Product_2008.idc
+LOCAL_MODULE_CLASS := ETC
+LOCAL_MODULE_PATH := $(TARGET_OUT_VENDOR)/usr/idc
+LOCAL_MODULE_TAGS := optional
+LOCAL_MODULE_OWNER := nintendo
+include $(BUILD_PREBUILT)

--- a/android/Vendor_057e_Product_2008.idc
+++ b/android/Vendor_057e_Product_2008.idc
@@ -1,0 +1,1 @@
+device.internal = 0

--- a/android/Vendor_057e_Product_2008.kl
+++ b/android/Vendor_057e_Product_2008.kl
@@ -1,0 +1,23 @@
+key 309   BACK
+key 314   BUTTON_SELECT
+key 318   BUTTON_THUMBR
+key 317   BUTTON_THUMBL
+key 304   BUTTON_A
+key 305   BUTTON_B
+key 308   BUTTON_X
+key 307   BUTTON_Y
+key 310   BUTTON_L1
+key 311   BUTTON_R1
+key 312   BUTTON_L2
+key 313   BUTTON_R2
+key 315   BUTTON_START
+key 316   HOME
+key 544   DPAD_UP
+key 545   DPAD_DOWN
+key 546   DPAD_LEFT
+key 547   DPAD_RIGHT
+
+axis 0x00 X
+axis 0x01 Y
+axis 0x03 Z
+axis 0x04 RZ

--- a/src/ctlr_detector_android.cpp
+++ b/src/ctlr_detector_android.cpp
@@ -44,7 +44,7 @@ bool ctlr_detector_android::check_ctlr_attributes(std::string devpath)
     if (vid != 0x57e)
         return false;
 
-    if (pid != 0x2009 && pid != 0x2007 && pid != 0x2006)
+    if (pid != 0x2007 && pid != 0x2006)
         return false;
 
     return true;


### PR DESCRIPTION
In android the pro controller uses standard HID due to hid-joycon not
working, so do not support it for the moment since we expect hid-joycon.

The keylayout allows the device to be correctly mapped and detected as a controller.