### PR TITLE
Remove executable bit from the service file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ install(FILES udev/89-joycond.rules udev/72-joycond.rules DESTINATION /lib/udev/
         PERMISSIONS OWNER_WRITE OWNER_READ GROUP_READ WORLD_READ 
         )
 install(FILES systemd/joycond.service DESTINATION /etc/systemd/system
-        PERMISSIONS OWNER_WRITE OWNER_READ OWNER_EXECUTE GROUP_READ WORLD_READ
+        PERMISSIONS OWNER_WRITE OWNER_READ GROUP_READ WORLD_READ
         )
 install(FILES systemd/joycond.conf DESTINATION /etc/modules-load.d
         PERMISSIONS OWNER_WRITE OWNER_READ GROUP_READ WORLD_READ


### PR DESCRIPTION
There is no need to set it this way.
Systemd report:
`Configuration file /etc/systemd/system/joycond.service is marked executable. Please remove executable permission bits. Proceeding anyway.`