### PR TITLE
Do not map SL/SR buttons if connected via serial

### DIFF
--- a/src/virt_ctlr_combined.cpp
+++ b/src/virt_ctlr_combined.cpp
@@ -16,6 +16,7 @@ void virt_ctlr_combined::relay_events(std::shared_ptr<phys_ctlr> phys)
 {
     struct input_event ev;
     struct libevdev *evdev = phys->get_evdev();
+    bool is_serial;
 
     int ret = libevdev_next_event(evdev, LIBEVDEV_READ_FLAG_NORMAL, &ev);
     while (ret == LIBEVDEV_READ_STATUS_SYNC || ret == LIBEVDEV_READ_STATUS_SUCCESS) {
@@ -26,13 +27,16 @@ void virt_ctlr_combined::relay_events(std::shared_ptr<phys_ctlr> phys)
                 ret = libevdev_next_event(evdev, LIBEVDEV_READ_FLAG_SYNC, &ev);
             }
         } else if (ret == LIBEVDEV_READ_STATUS_SUCCESS) {
+            is_serial = phys->is_serial_ctlr();
             /* First remap the SL and SR buttons on each physical controller */
             if (phys == physl && ev.type == EV_KEY && (ev.code == BTN_TR || ev.code == BTN_TR2)) {
-                libevdev_uinput_write_event(uidev, ev.type, ev.code == BTN_TR ? BTN_0 : BTN_1, ev.value);
+                if (!is_serial)
+                    libevdev_uinput_write_event(uidev, ev.type, ev.code == BTN_TR ? BTN_0 : BTN_1, ev.value);
                 ret = libevdev_next_event(evdev, LIBEVDEV_READ_FLAG_NORMAL, &ev);
                 continue;
             } else if (phys == physr && ev.type == EV_KEY && (ev.code == BTN_TL || ev.code == BTN_TL2)) {
-                libevdev_uinput_write_event(uidev, ev.type, ev.code == BTN_TL ? BTN_2: BTN_3, ev.value);
+                if (!is_serial)
+                    libevdev_uinput_write_event(uidev, ev.type, ev.code == BTN_TL ? BTN_2: BTN_3, ev.value);
                 ret = libevdev_next_event(evdev, LIBEVDEV_READ_FLAG_NORMAL, &ev);
                 continue;
             }
@@ -218,11 +222,14 @@ virt_ctlr_combined::virt_ctlr_combined(std::shared_ptr<phys_ctlr> physl, std::sh
     libevdev_enable_event_code(virt_evdev, EV_KEY, BTN_TR, NULL);
     libevdev_enable_event_code(virt_evdev, EV_KEY, BTN_TL2, NULL);
     libevdev_enable_event_code(virt_evdev, EV_KEY, BTN_TR2, NULL);
-    // Map the S triggers to these misc. buttons
-    libevdev_enable_event_code(virt_evdev, EV_KEY, BTN_0, NULL);
-    libevdev_enable_event_code(virt_evdev, EV_KEY, BTN_1, NULL);
-    libevdev_enable_event_code(virt_evdev, EV_KEY, BTN_2, NULL);
-    libevdev_enable_event_code(virt_evdev, EV_KEY, BTN_3, NULL);
+
+    // Map the S triggers to these misc. buttons if not connected via serial.
+    if (!physl->is_serial_ctlr() && !physr->is_serial_ctlr()) {
+        libevdev_enable_event_code(virt_evdev, EV_KEY, BTN_0, NULL);
+        libevdev_enable_event_code(virt_evdev, EV_KEY, BTN_1, NULL);
+        libevdev_enable_event_code(virt_evdev, EV_KEY, BTN_2, NULL);
+        libevdev_enable_event_code(virt_evdev, EV_KEY, BTN_3, NULL);
+    }
 
     struct input_absinfo absconfig = { 0 };
     absconfig.minimum = -32767;


### PR DESCRIPTION
The shoulder buttons are normally not accessible when connected via uart-serial (handheld mode).
This patch stops reporting them in such cases in order to not confuse various apps.