### PR TITLE
Installing CMake targets as opposed to installing targets' files.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ target_link_libraries(
 
 add_subdirectory(src)
 
-install(FILES joycond DESTINATION /usr/bin/
+install(TARGETS joycond DESTINATION /usr/bin/
         PERMISSIONS OWNER_WRITE OWNER_READ OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
         )
 install(FILES udev/89-joycond.rules udev/72-joycond.rules DESTINATION /lib/udev/rules.d/


### PR DESCRIPTION
It was not possible to run the CMake configuration step in a different directory other than the root directory of the project, as CMake would then not be capable of locating the `joycond` executable file at installation time.

As an example, when running

```bash
cd /tmp
git clone https://github.com/DanielOgorchock/joycond.git
mkdir joycond-build-release
cd joycond-build-release
cmake ../joycond -DCMAKE_BUILD_TYPE=Release
cmake --build . --parallel
sudo cmake --build . --target install
```

, the following error was produced:

```
[100%] Built target joycond
Install the project...
-- Install configuration: "Release"
CMake Error at cmake_install.cmake:54 (file):
  file INSTALL cannot find "/tmp/joycond/joycond": No such
  file or directory.


Makefile:126: recipe for target 'install' failed
make: *** [install] Error 1
```

The fix consists of installing the `joycond` CMake target (via `install(TARGETS ...)`), instead of merely installing the `joycond` file.