### PR TITLE
Set Combined Joycons' player LED status

### DIFF
--- a/include/virt_ctlr_combined.h
+++ b/include/virt_ctlr_combined.h
@@ -41,6 +41,8 @@ class virt_ctlr_combined : public virt_ctlr
         virtual bool supports_hotplug() {return true;}
         virtual bool no_ctlrs_left();
         virtual bool mac_belongs(const std::string& mac) const;
+        virtual bool set_player_led(int index, bool on);
+        virtual bool set_all_player_leds(bool on);
         virtual bool set_player_leds_to_player(int player);
 };
 

--- a/include/virt_ctlr_combined.h
+++ b/include/virt_ctlr_combined.h
@@ -41,6 +41,7 @@ class virt_ctlr_combined : public virt_ctlr
         virtual bool supports_hotplug() {return true;}
         virtual bool no_ctlrs_left();
         virtual bool mac_belongs(const std::string& mac) const;
+        virtual bool set_player_leds_to_player(int player);
 };
 
 #endif

--- a/src/ctlr_mgr.cpp
+++ b/src/ctlr_mgr.cpp
@@ -98,6 +98,7 @@ void ctlr_mgr::add_combined_ctlr()
             found_slot = true;
             left->set_player_leds_to_player(i % 4 + 1);
             right->set_player_leds_to_player(i % 4 + 1);
+            combined->set_player_leds_to_player(paired_controllers.size() % 4 + 1);
             paired_controllers[i] = std::move(combined);
             break;
         }
@@ -105,6 +106,7 @@ void ctlr_mgr::add_combined_ctlr()
     if (!found_slot) {
         left->set_player_leds_to_player(paired_controllers.size() % 4 + 1);
         right->set_player_leds_to_player(paired_controllers.size() % 4 + 1);
+        combined->set_player_leds_to_player(paired_controllers.size() % 4 + 1);
         paired_controllers.push_back(std::move(combined));
     }
 

--- a/src/ctlr_mgr.cpp
+++ b/src/ctlr_mgr.cpp
@@ -98,7 +98,7 @@ void ctlr_mgr::add_combined_ctlr()
             found_slot = true;
             left->set_player_leds_to_player(i % 4 + 1);
             right->set_player_leds_to_player(i % 4 + 1);
-            combined->set_player_leds_to_player(paired_controllers.size() % 4 + 1);
+            combined->set_player_leds_to_player(i % 4 + 1);
             paired_controllers[i] = std::move(combined);
             break;
         }
@@ -262,4 +262,3 @@ void ctlr_mgr::remove_ctlr(const std::string& devpath)
             break;
     }
 }
-

--- a/src/virt_ctlr_combined.cpp
+++ b/src/virt_ctlr_combined.cpp
@@ -282,6 +282,13 @@ virt_ctlr_combined::virt_ctlr_combined(std::shared_ptr<phys_ctlr> physl, std::sh
     libevdev_set_id_bustype(virt_evdev, BUS_VIRTUAL);
     libevdev_set_id_version(virt_evdev, 0x0000);
 
+    // Enable LED events
+    libevdev_enable_event_type(virt_evdev, EV_LED);
+    libevdev_enable_event_code(virt_evdev, EV_LED, 0, NULL);
+    libevdev_enable_event_code(virt_evdev, EV_LED, 1, NULL);
+    libevdev_enable_event_code(virt_evdev, EV_LED, 2, NULL);
+    libevdev_enable_event_code(virt_evdev, EV_LED, 3, NULL);
+
     ret = libevdev_uinput_create_from_device(virt_evdev, LIBEVDEV_UINPUT_OPEN_MANAGED, &uidev);
     if (ret) {
         std::cerr << "Failed to create libevdev_uinput; " << ret << std::endl;
@@ -413,3 +420,15 @@ bool virt_ctlr_combined::mac_belongs(const std::string& mac) const
     return mac != "" && (mac == left_mac || mac == right_mac);
 }
 
+bool virt_ctlr_combined::set_player_leds_to_player(int player)
+{
+    if (player < 1 || player > 4) {
+        std::cerr << player << " is not a valid player led value\n";
+        return false;
+    }
+
+    for (int i = 0; i < player; i++) {
+        libevdev_uinput_write_event(uidev, EV_LED, 0, LIBEVDEV_LED_ON);
+    }
+    return true;
+}

--- a/src/virt_ctlr_combined.cpp
+++ b/src/virt_ctlr_combined.cpp
@@ -425,7 +425,7 @@ bool virt_ctlr_combined::set_player_led(int index, bool on)
     if (index > 3)
         return false;
 
-    libevdev_uinput_write_event(uidev, EV_LED, 0, on ? LIBEVDEV_LED_ON : LIBEVDEV_LED_OFF);
+    libevdev_uinput_write_event(uidev, EV_LED, index, on);
     return true;
 }
 

--- a/src/virt_ctlr_combined.cpp
+++ b/src/virt_ctlr_combined.cpp
@@ -420,6 +420,24 @@ bool virt_ctlr_combined::mac_belongs(const std::string& mac) const
     return mac != "" && (mac == left_mac || mac == right_mac);
 }
 
+bool virt_ctlr_combined::set_player_led(int index, bool on)
+{
+    if (index > 3)
+        return false;
+
+    libevdev_uinput_write_event(uidev, EV_LED, 0, on ? LIBEVDEV_LED_ON : LIBEVDEV_LED_OFF);
+    return true;
+}
+
+bool virt_ctlr_combined::set_all_player_leds(bool on)
+{
+    for (int i = 0; i < 4; i++) {
+        if (!set_player_led(i, on))
+            return false;
+    }
+    return true;
+}
+
 bool virt_ctlr_combined::set_player_leds_to_player(int player)
 {
     if (player < 1 || player > 4) {
@@ -427,8 +445,9 @@ bool virt_ctlr_combined::set_player_leds_to_player(int player)
         return false;
     }
 
+    set_all_player_leds(false);
     for (int i = 0; i < player; i++) {
-        libevdev_uinput_write_event(uidev, EV_LED, 0, LIBEVDEV_LED_ON);
+        set_player_led(i, true);
     }
     return true;
 }


### PR DESCRIPTION
Possible solution to both https://github.com/DanielOgorchock/joycond/issues/48 and https://github.com/joaorb64/joycond-cemuhook/issues/27

`evdev` has set LED codes, so the virtual device mappings end up showing up as `LED_NUML`, `LED_CAPSL`, `LED_SCROLLL`, and `LED_COMPOSE`, but their codes are 0, 1, 2, and 3.

`evtest` displays:
```
Event type 17 (EV_LED)
    Event code 0 (LED_NUML) state 1
    Event code 1 (LED_CAPSL) state 0
    Event code 2 (LED_SCROLLL) state 0
    Event code 3 (LED_COMPOSE) state 0
```

while `/sys/class/input/inputX` has:
```
inputX::numlock/brightness
inputX::capslock/brightness
inputX::scrolllock/brightness
inputX::compose/brightness
```

I'm not sure if this is the best possible way to do this or if this is too much of a stretch, but this is what I could come up with.