### PR TITLE
Silence "Unhandled uinput type" error for EV_LED events

### DIFF
--- a/src/virt_ctlr_combined.cpp
+++ b/src/virt_ctlr_combined.cpp
@@ -173,6 +173,9 @@ void virt_ctlr_combined::handle_uinput_event()
                 }
                 break;
 
+            case EV_LED:
+                break;
+
             default:
                 std::cerr << "Unhandled uinput type=" << ev.type << std::endl;
                 break;


### PR DESCRIPTION
I noticed that after #49, these errors are written to the log sometimes. An EV_LED case should be added to `handle_uinput_event` to silence this error. Not sure if the case should be 'handled' somehow, because right now the LED events work correctly, so I just added the case with no additional code to 'handle' it.