### PR TITLE
Prevent leds from turning off after they've been set

### DIFF
--- a/src/virt_ctlr_combined.cpp
+++ b/src/virt_ctlr_combined.cpp
@@ -174,6 +174,9 @@ void virt_ctlr_combined::handle_uinput_event()
                 break;
 
             case EV_LED:
+                if (ev.value == 0) {
+                    libevdev_uinput_write_event(uidev, EV_LED, ev.code, !ev.value);
+                }
                 break;
 
             default:
@@ -448,7 +451,6 @@ bool virt_ctlr_combined::set_player_leds_to_player(int player)
         return false;
     }
 
-    set_all_player_leds(false);
     for (int i = 0; i < player; i++) {
         set_player_led(i, true);
     }


### PR DESCRIPTION
For some reason, when setting the leds for the second controller, the leds for the first controllers are turned off. I have no idea why it happens (there is no call to `set_player_led` that generates that event).
This commit should prevent the leds from turning off.

To prevent leds turning on accidentally, `set_all_player_leds(false)` is omitted. This call is pointless, because these aren't real leds anyway.