### PR TITLE
Android joycond support updates

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -20,6 +20,8 @@ LOCAL_SHARED_LIBRARIES := \
     liblog
 
 LOCAL_REQUIRED_MODULES := \
+    Vendor_057e_Product_2006.idc \
+    Vendor_057e_Product_2007.idc \
     Vendor_057e_Product_2008.idc \
     Vendor_057e_Product_2008.kl  \
     Vendor_057e_Product_2009_Version_8001.idc \
@@ -32,6 +34,24 @@ LOCAL_CPPFLAGS := -std=c++17 -Wno-error -fexceptions
 LOCAL_VENDOR_MODULE := true
 LOCAL_MODULE_OWNER := nintendo
 include $(BUILD_EXECUTABLE)
+
+include $(CLEAR_VARS)
+LOCAL_MODULE := Vendor_057e_Product_2007.idc
+LOCAL_SRC_FILES := android/Vendor_057e_Product_2006.idc
+LOCAL_MODULE_CLASS := ETC
+LOCAL_MODULE_PATH := $(TARGET_OUT_VENDOR)/usr/idc
+LOCAL_MODULE_TAGS := optional
+LOCAL_MODULE_OWNER := nintendo
+include $(BUILD_PREBUILT)
+
+include $(CLEAR_VARS)
+LOCAL_MODULE := Vendor_057e_Product_2006.idc
+LOCAL_SRC_FILES := android/Vendor_057e_Product_2006.idc
+LOCAL_MODULE_CLASS := ETC
+LOCAL_MODULE_PATH := $(TARGET_OUT_VENDOR)/usr/idc
+LOCAL_MODULE_TAGS := optional
+LOCAL_MODULE_OWNER := nintendo
+include $(BUILD_PREBUILT)
 
 include $(CLEAR_VARS)
 LOCAL_MODULE := Vendor_057e_Product_2008.kl

--- a/android/Vendor_057e_Product_2006.idc
+++ b/android/Vendor_057e_Product_2006.idc
@@ -1,0 +1,1 @@
+device.disabled=1

--- a/src/ctlr_detector_android.cpp
+++ b/src/ctlr_detector_android.cpp
@@ -120,7 +120,7 @@ void ctlr_detector_android::epoll_event_callback(int event_fd)
     if (devpath.empty() || devnode.empty() || ((devnode.find("event") == std::string::npos) && (devnode.find("hid") == std::string::npos)))
         return;
 
-    devpath = "/class/input/" + std::string(basename(devnode.c_str())) + "/device/device";
+    devpath = "/class/input/" + std::string(basename(devnode.c_str())) + "/device";
 
     // Sleep a bit to let driver load
     usleep(100000);
@@ -158,7 +158,7 @@ ctlr_detector_android::ctlr_detector_android(ctlr_mgr& ctlr_manager, epoll_mgr& 
             continue;
 
         event_path = "/dev/input/" + std::string(event_dirent->d_name);
-        sysfs_event_path = "/class/input/" + std::string(event_dirent->d_name) + "/device/device";
+        sysfs_event_path = "/class/input/" + std::string(event_dirent->d_name) + "/device";
   
         if (check_ctlr_attributes(event_path)) {
             ctlr_manager.add_ctlr(sysfs_event_path, event_path);


### PR DESCRIPTION
Adds LED support for Android and adds an idc to make apps ignore the individual joycons as some get confused by having three controllers.