### PR TITLE
android: Work around android bluetooth disconnect delay

### DIFF
--- a/include/ctlr_detector_android.h
+++ b/include/ctlr_detector_android.h
@@ -12,6 +12,7 @@ class ctlr_detector_android
         std::shared_ptr<epoll_subscriber> subscriber;
 
         std::map<std::string, std::string> ctlr_dev_map;
+        std::map<std::string, std::string> ctlr_mac_map;
 
         bool check_ctlr_attributes(std::string devpath);
         void scan_removed_ctlrs();


### PR DESCRIPTION
Android has some latency when reporting BT disconnect events which leads
to the serial event sometimes getting there before the disconnect event
and messing up the pairings, fix this by ensuring only one controller
with the same mac exists.