### PR TITLE
Add Fedora install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ hid-nintendo is currently in review on the linux-input mailing list. The most re
 
 # Installation
 1. clone the repo
-2. Install libevdev-dev if you haven't already (`sudo apt install libevdev-dev`)
+2. Install requirements (`sudo apt install libevdev-dev` or `sudo dnf install libevdev-devel libudev-devel`)
 3. `cmake .`
 4. `sudo make install`
 5. `sudo systemctl enable --now joycond`


### PR DESCRIPTION
Fixes #68

For joycond to work on Fedora you need `libevdev-devel` and 'libudev-devel` installed.