### PR TITLE
Install joycond.service to /usr/lib/systemd/system instead of /etc/systemd/system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ install(TARGETS joycond DESTINATION /usr/bin/
 install(FILES udev/89-joycond.rules udev/72-joycond.rules DESTINATION /lib/udev/rules.d/
         PERMISSIONS OWNER_WRITE OWNER_READ GROUP_READ WORLD_READ 
         )
-install(FILES systemd/joycond.service DESTINATION /etc/systemd/system
+install(FILES systemd/joycond.service DESTINATION /usr/lib/systemd/system
         PERMISSIONS OWNER_WRITE OWNER_READ GROUP_READ WORLD_READ
         )
 install(FILES systemd/joycond.conf DESTINATION /etc/modules-load.d


### PR DESCRIPTION
This is the standard location for systemd service files. I initially posted a comment about this [on the AUR package](https://aur.archlinux.org/packages/joycond-git) but the maintainer told me to get it fixed upstream instead.