### PR TITLE
Support for third party joycons and xbox orientation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "moonlight"]
+	path = moonlight
+	url = git@github.com:/lainproliant/moonlight

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.13)
 project(joycond)
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 
 # Generate compile_commands.json
 set(CMAKE_EXPORT_COMPILE_COMMANDS 1)
@@ -14,6 +14,7 @@ add_executable(joycond "")
 target_compile_options(joycond PRIVATE -Wall -Werror)
 include_directories(
     include/
+    moonlight/include/
     ${LIBEVDEV_INCLUDE_DIRS}
     ${LIBUDEV_INCLUDE_DIRS}
     )
@@ -29,7 +30,7 @@ install(TARGETS joycond DESTINATION /usr/bin/
         PERMISSIONS OWNER_WRITE OWNER_READ OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
         )
 install(FILES udev/89-joycond.rules udev/72-joycond.rules DESTINATION /lib/udev/rules.d/
-        PERMISSIONS OWNER_WRITE OWNER_READ GROUP_READ WORLD_READ 
+        PERMISSIONS OWNER_WRITE OWNER_READ GROUP_READ WORLD_READ
         )
 install(FILES systemd/joycond.service DESTINATION /etc/systemd/system
         PERMISSIONS OWNER_WRITE OWNER_READ GROUP_READ WORLD_READ

--- a/README.md
+++ b/README.md
@@ -5,9 +5,10 @@ hid-nintendo is currently in review on the linux-input mailing list. The most re
 # Installation
 1. clone the repo
 2. Install requirements (`sudo apt install libevdev-dev` or `sudo dnf install libevdev-devel libudev-devel`)
-3. `cmake .`
-4. `sudo make install`
-5. `sudo systemctl enable --now joycond`
+3. `git submodule update --init --recursive`
+4. `cmake .`
+5. `sudo make install`
+6. `sudo systemctl enable --now joycond`
 
 # Usage
 When a joy-con or pro controller is connected via bluetooth or USB, the player LEDs should start blinking periodically. This signals that the controller is in pairing mode.

--- a/build_deb.sh
+++ b/build_deb.sh
@@ -9,6 +9,7 @@ architecture="arm64"
 install_root="$(pwd)/build/deb/joycond"
 package_version="0.4-0"
 
+git submodule update --init --recursive
 mkdir -p "$install_root" || exit
 cmake . || exit
 make DESTDIR="$install_root" install || exit

--- a/include/config.h
+++ b/include/config.h
@@ -4,6 +4,12 @@
 #include "phys_ctlr.h"
 #include <map>
 
+typedef std::pair<std::string, std::string> CombinedMACs;
+
+struct ControllerProps {
+    bool xbox_orientation = false;
+};
+
 class Config {
 public:
     Config(const std::string& filename = "/etc/joycond.conf");
@@ -12,12 +18,16 @@ public:
     static const Config& get();
 
     std::optional<phys_ctlr::Model> get_mac_device_override(const std::string& mac_addr) const;
+    const ControllerProps& get_combined_joycons_props(const CombinedMACs& macs) const;
+    void set_combined_joycons_props(const CombinedMACs& macs, const ControllerProps& props);
 
 private:
     void process_config_file(std::istream& infile);
     void process_config_line(const std::string& line);
+    void parse_and_set_controller_prop(ControllerProps& props, const std::string& name, const std::string& value) const;
 
     std::map<std::string, phys_ctlr::Model> _mac_model_overrides;
+    std::map<CombinedMACs, ControllerProps> _combined_joycons_props;
 };
 
 #endif /* !JOYCOND_CONFIG_H */

--- a/include/config.h
+++ b/include/config.h
@@ -1,0 +1,23 @@
+#ifndef JOYCOND_CONFIG_H
+#define JOYCOND_CONFIG_H
+
+#include "phys_ctlr.h"
+#include <map>
+
+class Config {
+public:
+    Config(const std::string& filename = "/etc/joycond.conf");
+    ~Config() { }
+
+    static const Config& get();
+
+    std::optional<phys_ctlr::Model> get_mac_device_override(const std::string& mac_addr) const;
+
+private:
+    void process_config_file(std::istream& infile);
+    void process_config_line(const std::string& line);
+
+    std::map<std::string, phys_ctlr::Model> _mac_model_overrides;
+};
+
+#endif /* !JOYCOND_CONFIG_H */

--- a/include/phys_ctlr.h
+++ b/include/phys_ctlr.h
@@ -5,12 +5,16 @@
 #include <libevdev/libevdev.h>
 #include <optional>
 #include <string>
+#include <map>
 
 class phys_ctlr
 {
     public:
         enum class Model { Procon, Snescon, Left_Joycon, Right_Joycon, Unknown };
         enum class PairingState { Pairing, Lone, Waiting, Horizontal, Virt_Procon };
+
+        static const std::map<std::string, Model>& models_by_name();
+        static const std::map<Model, std::string>& names_by_model();
 
     private:
         std::string devpath;

--- a/include/virt_ctlr_combined.h
+++ b/include/virt_ctlr_combined.h
@@ -4,6 +4,7 @@
 #include "virt_ctlr.h"
 #include "phys_ctlr.h"
 #include "epoll_mgr.h"
+#include "config.h"
 
 #include <libevdev/libevdev.h>
 #include <map>
@@ -22,6 +23,7 @@ class virt_ctlr_combined : public virt_ctlr
         std::map<int, std::pair<struct ff_effect, struct ff_effect>> rumble_effects;
         std::string left_mac;
         std::string right_mac;
+        ControllerProps props;
 
         void relay_events(std::shared_ptr<phys_ctlr> phys);
         void handle_uinput_event();

--- a/joycond.conf.example
+++ b/joycond.conf.example
@@ -1,0 +1,2 @@
+mac_device 98:B6:E9:F8:6F:86 Left_Joycon
+mac_device 98:B6:E9:33:EF:5C Right_Joycon

--- a/joycond.conf.example
+++ b/joycond.conf.example
@@ -1,2 +1,3 @@
 mac_device 98:B6:E9:F8:6F:86 Left_Joycon
 mac_device 98:B6:E9:33:EF:5C Right_Joycon
+prop combined_joycons 98:B6:E9:F8:6F:86 98:B6:E9:33:EF:5C xbox_orientation 1

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,6 +2,7 @@ target_sources(
     joycond
     PRIVATE
         main.cpp
+        config.cpp
         phys_ctlr.cpp
         virt_ctlr.cpp
         virt_ctlr_passthrough.cpp
@@ -12,4 +13,3 @@ target_sources(
         ctlr_detector_udev.cpp
         ctlr_mgr.cpp
     )
-

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1,0 +1,67 @@
+#include "config.h"
+#include "moonlight/file.h"
+#include "moonlight/shlex.h"
+
+static const Config _config;
+
+// ctor
+Config::Config(const std::string& filename) {
+    try {
+        auto infile = moonlight::file::open_r(filename);
+        process_config_file(infile);
+
+    } catch (const moonlight::core::RuntimeError& e) {
+        std::cout << "Failed to open config file " << filename << ", skipping." << std::endl;
+    }
+}
+
+// public static
+const Config& Config::get() {
+    return _config;
+}
+
+// public
+std::optional<phys_ctlr::Model> Config::get_mac_device_override(const std::string& mac_addr) const {
+    auto iter = _mac_model_overrides.find(mac_addr);
+    if (iter == _mac_model_overrides.end()) {
+        return {};
+    }
+    return iter->second;
+}
+
+// private
+void Config::process_config_file(std::istream& infile) {
+    std::string line;
+    while (std::getline(infile, line)) {
+        process_config_line(line);
+    }
+}
+
+// private
+void Config::process_config_line(const std::string& line) {
+    auto tokens = moonlight::shlex::split(line);
+    if (tokens.size() < 1) {
+        return;
+    }
+
+    if (tokens[0] == "mac_device") {
+        if (tokens.size() != 3) {
+            std::cout << "Malformed `mac_device` directive in config file." << std::endl;
+            return;
+        }
+
+        auto mac_address = tokens[1];
+        auto device_name = tokens[2];
+
+        auto iter = phys_ctlr::models_by_name().find(device_name);
+        if (iter == phys_ctlr::models_by_name().end()) {
+            std::cout << "Invalid device name in `mac_device` directive: " << device_name << std::endl;
+            return;
+        }
+
+        _mac_model_overrides[mac_address] = iter->second;
+
+    } else {
+        std::cout << "Unknown directive in config file: " << tokens[0] << std::endl;
+    }
+}

--- a/src/ctlr_detector_udev.cpp
+++ b/src/ctlr_detector_udev.cpp
@@ -49,7 +49,7 @@ ctlr_detector_udev::ctlr_detector_udev(ctlr_mgr& ctlr_manager, epoll_mgr& epoll_
     udev_mon_fd = udev_monitor_get_fd(mon);
 
     subscriber = std::make_shared<epoll_subscriber>(std::vector({udev_mon_fd}),
-                                                    [=](int event_fd){epoll_event_callback(event_fd);});
+                                                    [=, this](int event_fd){epoll_event_callback(event_fd);});
     epoll_manager.add_subscriber(subscriber);
 
     // Detect any existing controllers prior to daemon start
@@ -83,4 +83,3 @@ ctlr_detector_udev::~ctlr_detector_udev()
 {
     epoll_manager.remove_subscriber(subscriber);
 }
-

--- a/src/ctlr_mgr.cpp
+++ b/src/ctlr_mgr.cpp
@@ -168,7 +168,7 @@ void ctlr_mgr::add_ctlr(const std::string& devpath, const std::string& devname)
         unpaired_controllers[devpath] = phys;
         phys->blink_player_leds();
         subscribers[devpath] = std::make_shared<epoll_subscriber>(std::vector({phys->get_fd()}),
-                                                [=](int event_fd){epoll_event_callback(event_fd);});
+                                                [=, this](int event_fd){epoll_event_callback(event_fd);});
         epoll_manager.add_subscriber(subscribers[devpath]);
     } else {
         std::cerr << "Attempting to add existing phys_ctlr to controller manager\n";

--- a/src/virt_ctlr_combined.cpp
+++ b/src/virt_ctlr_combined.cpp
@@ -341,7 +341,7 @@ virt_ctlr_combined::virt_ctlr_combined(std::shared_ptr<phys_ctlr> physl, std::sh
     fcntl(get_uinput_fd(), F_SETFL, flags | O_NONBLOCK);
 
     subscriber = std::make_shared<epoll_subscriber>(std::vector({get_uinput_fd()}),
-                                                    [=](int event_fd){handle_events(event_fd);});
+                                                    [=, this](int event_fd){handle_events(event_fd);});
     epoll_manager.add_subscriber(subscriber);
 }
 

--- a/src/virt_ctlr_combined.cpp
+++ b/src/virt_ctlr_combined.cpp
@@ -1,4 +1,5 @@
 #include "virt_ctlr_combined.h"
+#include "config.h"
 
 #include <cstring>
 #include <fcntl.h>
@@ -76,7 +77,34 @@ void virt_ctlr_combined::relay_events(std::shared_ptr<phys_ctlr> phys)
                 }
             }
 #endif
-            libevdev_uinput_write_event(uidev, ev.type, ev.code, ev.value);
+
+            // Swap X/Y and A/B if xbox_orientation is enabled for this controller.
+            if (props.xbox_orientation) {
+                switch (ev.code) {
+                    case BTN_X:
+                        libevdev_uinput_write_event(uidev, ev.type, BTN_Y, ev.value);
+                        break;
+
+                    case BTN_Y:
+                        libevdev_uinput_write_event(uidev, ev.type, BTN_X, ev.value);
+                        break;
+
+                    case BTN_A:
+                        libevdev_uinput_write_event(uidev, ev.type, BTN_B, ev.value);
+                        break;
+
+                    case BTN_B:
+                        libevdev_uinput_write_event(uidev, ev.type, BTN_A, ev.value);
+                        break;
+
+                    default:
+                        libevdev_uinput_write_event(uidev, ev.type, ev.code, ev.value);
+                        break;
+                }
+
+            } else {
+                libevdev_uinput_write_event(uidev, ev.type, ev.code, ev.value);
+            }
         }
         ret = libevdev_next_event(evdev, LIBEVDEV_READ_FLAG_NORMAL, &ev);
     }
@@ -234,6 +262,9 @@ virt_ctlr_combined::virt_ctlr_combined(std::shared_ptr<phys_ctlr> physl, std::sh
     right_mac(physr->get_mac_addr())
 {
     int ret;
+
+    const Config& config = Config::get();
+    props = config.get_combined_joycons_props({left_mac, right_mac});
 
     uifd = open("/dev/uinput", O_RDWR);
     if (uifd < 0) {

--- a/src/virt_ctlr_pro.cpp
+++ b/src/virt_ctlr_pro.cpp
@@ -261,7 +261,7 @@ virt_ctlr_pro::virt_ctlr_pro(std::shared_ptr<phys_ctlr> phys, epoll_mgr& epoll_m
     fcntl(get_uinput_fd(), F_SETFL, flags | O_NONBLOCK);
 
     subscriber = std::make_shared<epoll_subscriber>(std::vector({get_uinput_fd()}),
-                                                    [=](int event_fd){handle_events(event_fd);});
+                                                    [=, this](int event_fd){handle_events(event_fd);});
     epoll_manager.add_subscriber(subscriber);
 }
 


### PR DESCRIPTION
These two commits add the following:

-  An `/etc/joycond.conf` config file allowing for the following:
   - A `mac_device` directive allowing the device type to be overridden on a per-MAC basis.  This allows the usage of third-party joycons such as the [Binbok](https://binbok.com/product/binbok-wireless-rgb-joycon-controller-for-switch-switch-oled-black/) that report their device type incorrectly.
   - A `prop` directive allowing settings for combined joycons to be specified.
      - An `xbox_orientation` property swapping X/Y and A/B, making the combined controller behave more like an XBOX controller, preventing the need for remapping in many games that expect this button orientation.

Please let me know your thoughts.  I included my `moonlight` utility lib mainly for `shlex::split` which is used in parsing the config file, but I can refactor this out if you'd prefer.  I'm happy to follow any suggestions and make changes.  Thanks for building and maintaining this awesome daemon!
