### PR TITLE
add c++ to "sudo dnf install.. "

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ hid-nintendo is currently in review on the linux-input mailing list. The most re
 
 # Installation
 1. clone the repo
-2. Install requirements (`sudo apt install libevdev-dev` or `sudo dnf install libevdev-devel libudev-devel`)
+2. Install requirements (`sudo apt install libevdev-dev` or `sudo dnf install libevdev-devel libudev-devel c++`)
 3. `cmake .`
 4. `sudo make install`
 5. `sudo systemctl enable --now joycond`


### PR DESCRIPTION
I added "c++"  to the dnf the instructions in the part Installation.
As it seems required to avoid the following error:
```
CMake Error at CMakeLists.txt:2 (project):
  No CMAKE_CXX_COMPILER could be found.
```
