### PR TITLE
fix: install manpage with CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,3 +37,6 @@ install(FILES systemd/joycond.service DESTINATION /etc/systemd/system
 install(FILES systemd/joycond.conf DESTINATION /etc/modules-load.d
         PERMISSIONS OWNER_WRITE OWNER_READ GROUP_READ WORLD_READ
         )
+install(FILES doc/joycond.1 DESTINATION /usr/share/man/man1
+        PERMISSIONS OWNER_WRITE OWNER_READ GROUP_READ WORLD_READ
+        )


### PR DESCRIPTION
The manpage (at `doc/joycond.1`) is not installed with CMake which is useful for prebuilt packages. Closes issue #70