### PR TITLE
virt_ctrlr_passthrough: send uevent change event when unlocked

### DIFF
--- a/src/virt_ctlr_passthrough.cpp
+++ b/src/virt_ctlr_passthrough.cpp
@@ -14,6 +14,11 @@ virt_ctlr_passthrough::virt_ctlr_passthrough(std::shared_ptr<phys_ctlr> phys) :
     // Allow other processes to use the input now.
     if (fchmod(phys->get_fd(), S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH))
         std::cerr << "Failed to change evdev permissions; " << strerror(errno) << std::endl;
+    // Inform other processes the input is usable now.
+    std::ofstream uevent;
+    uevent.open("/sys" + phys->get_devpath() + "/uevent");
+    uevent << "change";
+    uevent.close();
     phys->ungrab();
 }
 


### PR DESCRIPTION
Some apps use udev polling of events to detect controllers. Current udev rules block single joycons before joycond decides the pairing state, so if an app is polling for an event change to add controllers, it will detect the changes, and be unable to open the controller event file. This sends a new event for the polling system in the app to detect, so it can re-configure the controller.