### PR TITLE
Install systemd and udev rules under /usr

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ add_subdirectory(src)
 install(TARGETS joycond DESTINATION /usr/bin/
         PERMISSIONS OWNER_WRITE OWNER_READ OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
         )
-install(FILES udev/89-joycond.rules udev/72-joycond.rules DESTINATION /lib/udev/rules.d/
+install(FILES udev/89-joycond.rules udev/72-joycond.rules DESTINATION /usr/lib/udev/rules.d/
         PERMISSIONS OWNER_WRITE OWNER_READ GROUP_READ WORLD_READ 
         )
 install(FILES systemd/joycond.service DESTINATION /etc/systemd/system

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ install(TARGETS joycond DESTINATION /usr/bin/
 install(FILES udev/89-joycond.rules udev/72-joycond.rules DESTINATION /usr/lib/udev/rules.d/
         PERMISSIONS OWNER_WRITE OWNER_READ GROUP_READ WORLD_READ 
         )
-install(FILES systemd/joycond.service DESTINATION /etc/systemd/system
+install(FILES systemd/joycond.service DESTINATION /usr/lib/systemd/system
         PERMISSIONS OWNER_WRITE OWNER_READ GROUP_READ WORLD_READ
         )
 install(FILES systemd/joycond.conf DESTINATION /etc/modules-load.d


### PR DESCRIPTION
While most of distros are getting rid of non-/usr direcories, installing systemd services under /etc is not the right practice for an installed software since the systemd services installed under /etc are meant for system administrators service files or service overrides, not for system-installed services