### PR TITLE
cmake: Only apply -Werror to debug builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ pkg_check_modules(LIBEVDEV REQUIRED libevdev)
 pkg_check_modules(LIBUDEV REQUIRED libudev)
 
 add_executable(joycond "")
-target_compile_options(joycond PRIVATE -Wall -Werror)
+target_compile_options(joycond PRIVATE -Wall $<$<CONFIG:Debug>:-Werror>)
 include_directories(
     include/
     ${LIBEVDEV_INCLUDE_DIRS}


### PR DESCRIPTION
It is really unhelpful for end users and distributions who might not be using the same toolchain version as you.